### PR TITLE
updated package.json to include antigen as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/sghall/subunit",
   "devDependencies": {
+    "antigen": "0.0.3",
     "babel": "^5.1.11",
     "babel-core": "^5.1.11",
     "es6-module-loader": "^0.16.6",


### PR DESCRIPTION
This solves issue #1. The demos run if antigen is included in package.json before `npm install`. 
