### PR TITLE
Fix raycasting for nested objects (.on handler)

### DIFF
--- a/demos/js/common/events.js
+++ b/demos/js/common/events.js
@@ -15,7 +15,7 @@ export function raycast(camera, items, type) {
 
     raycaster.ray.set(camera.position, vector.sub(camera.position).normalize());
 
-    var target = raycaster.intersectObjects(items);
+    var target = raycaster.intersectObjects(items, true);
 
     if (target.length) {
       target[0].type = type;


### PR DESCRIPTION
The .on handler on a subunit selection fails to be called if applied to nested objects unless raycasting intersectObjects is set to true. Not sure if this will impact other parts of the demos, but seems to work in my local testing.
